### PR TITLE
Only show the shroud if Xcode is up.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Xcode
+build/*
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+# Finder droppings
+.DS_Store
+
+# emacs droppings
+*~
+\#*
+.\#*
+

--- a/XcodeShroud/AppDelegate.m
+++ b/XcodeShroud/AppDelegate.m
@@ -7,22 +7,79 @@
 //
 
 #import "AppDelegate.h"
+#import "ShroudWindow.h"
 
 @interface AppDelegate ()
+@property (strong) IBOutlet ShroudWindow *window;
+@end // extension
 
-@property (weak) IBOutlet NSWindow *window;
-@end
 
 @implementation AppDelegate
 
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
-    // Insert code here to initialize your application
-}
+- (void) addWorkspaceHooks {
+    NSWorkspace *workspace = NSWorkspace.sharedWorkspace;
+
+    NSNotificationCenter *center = workspace.notificationCenter;
+
+    [center addObserver: self
+            selector: @selector(handleDidActivateApplication:)
+            name: NSWorkspaceDidActivateApplicationNotification
+            object: nil];
+
+#if SPY_ON_WORKSPACE_NOTIFICATIONS
+    [center addObserver: self
+            selector: @selector(handleWorkspaceNotification:)
+            name: nil  object: nil];
+#endif
+
+}// addWorkspaceHooks
 
 
-- (void)applicationWillTerminate:(NSNotification *)aNotification {
-    // Insert code here to tear down your application
-}
+- (void) show {
+    if (self.window.visible) return;
+    [self.window makeKeyAndOrderFront: self];
+} // show
+
+
+- (void) hide {
+    if (!self.window.visible) return;
+    [self.window orderOut: self];
+} // hide
+
+
+- (void) handleDidActivateApplication: (NSNotification *) notification {
+    NSDictionary *info = notification.userInfo;
+    NSRunningApplication *app = info[NSWorkspaceApplicationKey];
+
+    NSArray *bundlesToShroud = @[
+         @"com.apple.dt.Xcode",  // the source of all this pain
+         @"com.apple.finder",   // to make it easy to get a clickable shroud back
+         @"com.borkware.XcodeShroud"
+    ];
+
+    if ([bundlesToShroud containsObject: app.bundleIdentifier]) {
+        [self show];
+    } else {
+        [self hide];
+    }
+
+} // handleDidActivateApplication
+
+
+- (void) handleWorkspaceNotification: (NSNotification *) notification {
+    NSLog(@"%@ %@", notification.name, notification.userInfo);
+} // handleWorkspaceNotification
+
+
+- (void) applicationDidFinishLaunching: (NSNotification *) aNotification {
+    [self addWorkspaceHooks];
+} // applicationDidFinishLaunching
+
+
+- (void) applicationWillTerminate: (NSNotification *) aNotification {
+} // applicationWillTerminate
 
 
 @end
+
+


### PR DESCRIPTION
Gets in the way of other apps.